### PR TITLE
OP-547: Fix for error during registration when agreements are empty

### DIFF
--- a/spec/EventSubscriber/UserRegistrationAgreementSubscriberSpec.php
+++ b/spec/EventSubscriber/UserRegistrationAgreementSubscriberSpec.php
@@ -67,6 +67,7 @@ final class UserRegistrationAgreementSubscriberSpec extends ObjectBehavior
         $resourceControllerEvent->getSubject()->willReturn($customer);
         $customer->getUser()->willReturn($shopUser);
         $customer->getAgreements()->willReturn($userAgreements);
+        $userAgreements->isEmpty()->willReturn(false);
         $userAgreements->first()->willReturn($agreement);
         $agreement->getContexts()->willReturn(['registration_form']);
 

--- a/src/EventSubscriber/UserRegistrationAgreementSubscriber.php
+++ b/src/EventSubscriber/UserRegistrationAgreementSubscriber.php
@@ -49,6 +49,9 @@ class UserRegistrationAgreementSubscriber implements EventSubscriberInterface
 
         /** @var Collection $userAgreements */
         $userAgreements = $customer->getAgreements();
+        if ($userAgreements->isEmpty()) {
+            return;
+        }
 
         $context = $userAgreements->first()->getContexts()[0];
 

--- a/tests/Application/templates/bundles/SyliusShopBundle/Register/_form.html.twig
+++ b/tests/Application/templates/bundles/SyliusShopBundle/Register/_form.html.twig
@@ -10,7 +10,7 @@
 {{ form_row(form.user.plainPassword.first, sylius_test_form_attribute('password-first')) }}
 {{ form_row(form.user.plainPassword.second, sylius_test_form_attribute('password-second')) }}
 
-{% if form.agreements is defined %}
+{% if form.agreements is defined and form.agreements is not empty %}
     <h4 class="ui dividing header">{{ 'bitbag_sylius_agreement_plugin.ui.agreements'|trans }}</h4>
 
     {% for agreement in form.agreements %}


### PR DESCRIPTION
Also removed displaying empty h4 in twig when agreements are empty for better UX